### PR TITLE
chore: add wrangler.toml for Cloudflare Pages deployment

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -1,0 +1,3 @@
+name = "kastau"
+pages_build_output_dir = "dist"
+compatibility_date = "2025-01-01"


### PR DESCRIPTION
## Summary

- Tambah `wrangler.toml` di `apps/web/` untuk konfigurasi Cloudflare Pages
- Mengarahkan Pages build output ke `dist` (relatif dari `apps/web/`)

## Required Dashboard Changes

Setelah merge, update build settings di CF Pages → kastau → Settings → Build & deployments:

| Setting | Value |
|---|---|
| Build command | `pnpm --filter @kastau/web build` |
| Build output directory | `apps/web/dist` |
| Root directory | _(kosong)_ |

Tambah environment variable:
- `NODE_VERSION` = `22`

## Why

Setelah migrasi ke Turborepo monorepo, kode Astro dipindahkan ke `apps/web/`
sehingga build command dan output directory perlu diperbarui agar CF Pages
tetap bisa deploy dengan benar.
