### PR TITLE
fix: move PR template to correct .github directory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Tautan Isu 🔗:
+
+**Isu**: #[Nomor_Isu]
+
+## Jenis Perubahan
+
+- [ ] Perbaikan Bug 🐞
+- [ ] Fitur/Halaman Baru
+- [ ] Pembaruan Dokumentasi
+- [ ] Lainnya
+
+## Deskripsi 📋
+
+- **Apa:** Berikan gambaran umum tentang isu yang ditangani oleh PR ini. Jelaskan konteks dan informasi latar belakangnya.
+
+- **Mengapa:** Jelaskan mengapa perubahan ini dilakukan. Sebutkan poin penting, fitur baru, atau perbaikan bug yang dilakukan.
+
+- **Bagaimana:** Jelaskan bagaimana perubahan ini akan memengaruhi proyek atau pengguna akhir.
+
+## Daftar Periksa ✅
+
+- [ ] Mematuhi [Kode Etik](https://github.com/papuaopensource/papuaopensource.github.io?tab=coc-ov-file) dan [Panduan Kontribusi](https://papuaopensource.github.io/kontribusi/)
+- [ ] Menjalankan `pnpm format`
+- [ ] Menjalankan `pnpm lint`
+- [ ] Semua pengujian lolos secara lokal
+- [ ] Menambahkan pengujian (jika berlaku)
+- [ ] Dokumentasi diperbarui (jika berlaku)
+
+## Catatan Tambahan & Tangkapan Layar
+
+Tambahkan catatan atau komentar tambahan lainnya yang mungkin membantu bagi para peninjau.


### PR DESCRIPTION
## Tautan Isu 🔗:

**Isu**: #16

## Jenis Perubahan

- [x] Perbaikan Bug 🐞

## Deskripsi 📋

Moves `pull_request_template.md` to the correct location at `.github/pull_request_template.md`.

Previously it was placed under `.github/workflows/` which is reserved for GitHub Actions — GitHub does not recognize templates there and will not auto-populate PR descriptions.

## Daftar Periksa ✅

- [x] Mematuhi [Kode Etik](https://github.com/papuaopensource/papuaopensource.github.io?tab=coc-ov-file) dan [Panduan Kontribusi](https://papuaopensource.github.io/kontribusi/)
- [x] Dokumentasi diperbarui (jika berlaku)